### PR TITLE
feat: extract HATEOAS related link from parent

### DIFF
--- a/src/Resource.js
+++ b/src/Resource.js
@@ -9,8 +9,15 @@ const getOptionsQuery = (optionsObject = {}) =>
     .map(k => `${k}=${encodeURIComponent(optionsObject[k])}`)
     .join('&');
 
-const relatedResourceUrl = ({ parent, relationship }) =>
-  `${parent.type}/${parent.id}/${relationship}`;
+const relatedResourceUrl = ({ parent, relationship }) => {
+  if (
+    parent.relationships &&
+    Object.keys(parent.relationships).includes(relationship)
+  ) {
+    return parent.relationships[relationship].links.related;
+  }
+  return `${parent.type}/${parent.id}/${relationship}`;
+};
 
 const extractData = response => response.data;
 

--- a/test/Resource.spec.js
+++ b/test/Resource.spec.js
@@ -156,6 +156,21 @@ describe('Resource', () => {
       id: '1',
     };
 
+    const parentWithRelationship = relationship => ({
+      ...parent,
+      relationships: {
+        [relationship]: {
+          data: {
+            type: 'type',
+            id: '2',
+          },
+          links: {
+            related: 'related-link',
+          },
+        },
+      },
+    });
+
     it('can find related records', () => {
       const expectedResponse = { data: records };
       api.get.mockResolvedValue({ data: expectedResponse });
@@ -174,6 +189,20 @@ describe('Resource', () => {
       const result = resource.related({ parent, relationship });
 
       expect(api.get).toHaveBeenCalledWith('users/1/purchased-widgets?');
+      return expect(result).resolves.toEqual(expectedResponse);
+    });
+
+    it('can find related link with a parent has relationships', () => {
+      const expectedResponse = { data: records };
+      api.get.mockResolvedValue({ data: expectedResponse });
+
+      const relationship = 'purchased-widgets';
+      const result = resource.related({
+        parent: parentWithRelationship(relationship),
+        relationship,
+      });
+
+      expect(api.get).toHaveBeenCalledWith('related-link?');
       return expect(result).resolves.toEqual(expectedResponse);
     });
 


### PR DESCRIPTION
changes:
  - function 'relatedResourceUrl' can find relationship URL from parent
  - parent should have relationships[relationship].links.related
  - if not, it returns constructed URL

Signed-off-by: cmygray <cmygray@gmail.com>